### PR TITLE
fix: impede deleção do último mapa e centraliza nome padrão

### DIFF
--- a/src/js/map/map.manager.js
+++ b/src/js/map/map.manager.js
@@ -22,6 +22,7 @@ import {
 } from '../store';
 
 import { IDUtils } from '../utilities';
+import { DEFAULT_MAP_NAME } from '../store/store.constants.js';
 
 class MapManager {
     constructor(baseLayerControl, selectionManager) {
@@ -408,7 +409,7 @@ class MapManager {
                 this.selectionManager.deselectAllFeatures();
             }
 
-            setCurrentMap('Principal');
+            setCurrentMap(DEFAULT_MAP_NAME);
 
             if (this.baseLayerControl) {
                 await this.baseLayerControl.switchMap();

--- a/src/js/sidebar/tabs/maps.tab.js
+++ b/src/js/sidebar/tabs/maps.tab.js
@@ -510,7 +510,11 @@ export class MapsTab {
         // Close any existing menu
         this._closeContextMenu();
 
-        const locked = await isMapLocked(mapName);
+        const [locked, allMapNames] = await Promise.all([
+            isMapLocked(mapName),
+            getAllMapNamesStore()
+        ]);
+        const isLastMap = allMapNames.length <= 1;
 
         const menu = document.createElement('div');
         menu.className = 'map-context-menu';
@@ -562,14 +566,16 @@ export class MapsTab {
                 handler: () => this._handleCombineMaps(mapName)
             });
 
-            menuItems.push({ separator: true });
+            if (!isLastMap) {
+                menuItems.push({ separator: true });
 
-            menuItems.push({
-                icon: SIDEBAR_ICONS.trash,
-                label: 'Deletar',
-                handler: () => this._handleDeleteMap(mapName),
-                className: 'menu-item-danger'
-            });
+                menuItems.push({
+                    icon: SIDEBAR_ICONS.trash,
+                    label: 'Deletar',
+                    handler: () => this._handleDeleteMap(mapName),
+                    className: 'menu-item-danger'
+                });
+            }
         }
 
         // Build menu items

--- a/src/js/store/map.operations.js
+++ b/src/js/store/map.operations.js
@@ -184,6 +184,17 @@ export const removeMap = async (mapName) => {
         return { success: false, reason: 'PERMISSION_DENIED' };
     }
 
+    const allMaps = await getAllMapNames();
+
+    // Guard: prevent deleting the last map
+    if (allMaps.length <= 1) {
+        emitStoreError(StoreErrorEvents.STORE_OPERATION_BLOCKED, {
+            operation: 'removeMap',
+            reason: 'Não é possível deletar o último mapa'
+        });
+        return { success: false, reason: 'LAST_MAP' };
+    }
+
     const mapData = await getMapData(mapName);
     if (!mapData || Object.keys(mapData).length === 0) {
         console.warn(`Tentativa de remover mapa inexistente: ${mapName}`);
@@ -195,7 +206,6 @@ export const removeMap = async (mapName) => {
 
     const currentMapName = mapManager.getCurrentMapName();
     const isCurrentMap = mapName === currentMapName;
-    const allMaps = await getAllMapNames();
     const remainingMaps = allMaps.filter(name => name !== mapName);
 
     await deleteMapData(mapName);
@@ -216,13 +226,8 @@ export const removeMap = async (mapName) => {
     }
 
     if (isCurrentMap) {
-        if (remainingMaps.length > 0) {
-            const newCurrentMap = remainingMaps[0];
-            await setCurrentMap(newCurrentMap);
-        } else {
-            await addMap('Principal');
-            await setCurrentMap('Principal');
-        }
+        const newCurrentMap = remainingMaps[0];
+        await setCurrentMap(newCurrentMap);
     }
 
     // Log operation for sync
@@ -232,7 +237,7 @@ export const removeMap = async (mapName) => {
         success: true,
         wasCurrentMap: isCurrentMap,
         remainingMapsCount: remainingMaps.length,
-        newCurrentMap: isCurrentMap ? (remainingMaps.length > 0 ? remainingMaps[0] : 'Principal') : currentMapName
+        newCurrentMap: isCurrentMap ? remainingMaps[0] : currentMapName
     };
 };
 

--- a/src/js/store/memory-store.js
+++ b/src/js/store/memory-store.js
@@ -14,6 +14,8 @@
  * on page refresh.
  */
 
+import { DEFAULT_MAP_NAME } from './store.constants.js';
+
 // ===== MEMORY STORE =====
 
 /**
@@ -28,7 +30,7 @@ export const memoryStore = {
      * @type {Object.<string, {undoStacks: Object.<string, Array>, redoStacks: Object.<string, Array>}>}
      */
     maps: {
-        'Principal': {
+        [DEFAULT_MAP_NAME]: {
             undoStacks: {},
             redoStacks: {}
         }
@@ -38,7 +40,7 @@ export const memoryStore = {
      * Current active map name.
      * @type {string}
      */
-    currentMap: 'Principal',
+    currentMap: DEFAULT_MAP_NAME,
 
     /**
      * Flag indicating if an undo operation is in progress.
@@ -120,12 +122,12 @@ export const memoryStore = {
  */
 export function resetMemoryStore() {
     memoryStore.maps = {
-        'Principal': {
+        [DEFAULT_MAP_NAME]: {
             undoStacks: {},
             redoStacks: {}
         }
     };
-    memoryStore.currentMap = 'Principal';
+    memoryStore.currentMap = DEFAULT_MAP_NAME;
     memoryStore.isUndoing = false;
     memoryStore.isRedoing = false;
     memoryStore.batchCollector = null;

--- a/src/js/store/repository.js
+++ b/src/js/store/repository.js
@@ -20,6 +20,7 @@ import { detectMigrationNeeded, safelyMigrate } from './migration/migration.serv
 import { ATLAS_SCHEMA_VERSION } from './atlas/atlas.entity.js';
 import config from '../config.js';
 import { createSyncMetadata } from './sync/sync-metadata.js';
+import { DEFAULT_MAP_NAME } from './store.constants.js';
 
 // Re-export from repository.utils.js for backward compatibility
 export {
@@ -320,9 +321,9 @@ export const initializeRepository = async () => {
                 }];
             }
 
-            await mapStore.setItem('Principal', newMapData);
-            memoryStore.currentMap = 'Principal';
-            return 'Principal';
+            await mapStore.setItem(DEFAULT_MAP_NAME, newMapData);
+            memoryStore.currentMap = DEFAULT_MAP_NAME;
+            return DEFAULT_MAP_NAME;
         }
 
         const lastActiveMap = await appStore.getItem('lastActiveMap');
@@ -336,8 +337,8 @@ export const initializeRepository = async () => {
         }
     } catch (error) {
         console.error('Error initializing repository:', error);
-        memoryStore.currentMap = 'Principal';
-        return 'Principal';
+        memoryStore.currentMap = DEFAULT_MAP_NAME;
+        return DEFAULT_MAP_NAME;
     }
 };
 

--- a/src/js/store/store.constants.js
+++ b/src/js/store/store.constants.js
@@ -5,6 +5,12 @@
  */
 
 /**
+ * Default map name used when creating new atlases or resetting data.
+ * @constant {string}
+ */
+export const DEFAULT_MAP_NAME = 'Principal';
+
+/**
  * Mapping of feature source types to their icon paths.
  * @constant {Object<string, string>}
  */

--- a/src/js/store/store.js
+++ b/src/js/store/store.js
@@ -277,6 +277,7 @@ export const moveFeaturesToLayer = async (featureRefs, targetLayerId, mapName = 
 export {
     FEATURE_TYPE_ICONS,
     FEATURE_TYPE_LAYERS,
+    DEFAULT_MAP_NAME,
     FEATURE_TYPE_MAPPINGS,
     FEATURE_DISPLAY_NAMES,
     UNCOPYABLE_FEATURE_TYPES,


### PR DESCRIPTION
- Adiciona constante DEFAULT_MAP_NAME em store.constants.js para eliminar strings 'Principal' hardcoded pelo código
- Adiciona guarda em removeMap (store level) impedindo deleção quando só resta um mapa, emitindo STORE_OPERATION_BLOCKED
- Remove fallback que recriava mapa 'Principal' após deletar o último (agora impossível com a guarda)
- Oculta opção "Deletar" no menu de contexto do mapa quando só existe um mapa na lista
- Atualiza memory-store, repository e map.manager para usar a constante DEFAULT_MAP_NAME