### PR TITLE
fix: register CATALOG_ADD_LAYER listener eagerly in FeaturesTab const…

### DIFF
--- a/src/js/features_tab/features_tab.js
+++ b/src/js/features_tab/features_tab.js
@@ -117,6 +117,14 @@ export class FeaturesTab {
         // Attribute table control reference (set by external code)
         this._attributeTableControl = null;
 
+        // Register catalog layer listener eagerly (not in createUI) so it
+        // handles events even before the camadas tab is first opened.
+        this._catalogLayerUnsubscriber = initCatalogLayerListeners(
+            this.map,
+            this._eventBus,
+            this.analysisLayersManager,
+            this.dataLayersManager
+        );
     }
 
     /**
@@ -158,14 +166,6 @@ export class FeaturesTab {
         const featuresList = document.createElement('div');
         featuresList.className = 'features-list';
         this.container.appendChild(featuresList);
-
-        // Initialize catalog layer listeners
-        this._catalogLayerUnsubscriber = initCatalogLayerListeners(
-            this.map,
-            this._eventBus,
-            this.analysisLayersManager,
-            this.dataLayersManager
-        );
 
         // Initialize 3D models section listeners
         this._models3dSectionUnsubscriber = initModels3dSectionListeners(


### PR DESCRIPTION
The listener was registered in createUI() which only runs when the camadas tab is first opened. Since the catalog modal emits the event BEFORE calling expandSidebar('camadas'), the event was lost on the very first catalog layer addition (no listener existed yet). On the second attempt it worked because the first attempt's expandSidebar had triggered createUI and registered the listener.

Moving the registration to the constructor ensures the listener is always active as soon as FeaturesTab is instantiated during app init.