### PR TITLE
Fix briefing load buttons missing on new briefing creation

### DIFF
--- a/src/js/briefing/editor/briefing-editor.control.js
+++ b/src/js/briefing/editor/briefing-editor.control.js
@@ -650,7 +650,7 @@ export class BriefingEditorControl {
 
         const mapSelect = document.createElement('select');
         mapSelect.className = 'briefing-editor-select';
-        this._populateMapSelect(mapSelect, slide);
+        await this._populateMapSelect(mapSelect, slide);
         addDomListener(this, mapSelect, 'change', async () => {
             const previousMapId = slide.mapId;
             slide.mapId = mapSelect.value || null;


### PR DESCRIPTION
Await _populateMapSelect() in _renderSlideEditor() so that the auto-assigned mapId is available before the conditional button rendering checks. Without await, the async map name fetch resolved after the synchronous button checks, leaving slide.mapId as null and hiding the "load orientation" and "import notes" buttons.