### PR TITLE
feat: show clean read-only feature panel when map is locked

### DIFF
--- a/src/css/sidebar.css
+++ b/src/css/sidebar.css
@@ -871,6 +871,40 @@
     display: none;
 }
 
+/* Photo gallery hidden state (locked with no images) */
+.feature-photo-gallery--hidden {
+    display: none;
+}
+
+/* Photo gallery counter hidden state */
+.feature-photo-gallery-counter--hidden {
+    display: none;
+}
+
+/* Read-only attribute row: no hover effects, no delete button space */
+.feature-attribute-row--readonly {
+    cursor: default;
+}
+
+.feature-attribute-row--readonly .feature-attribute-key {
+    cursor: default;
+}
+
+.feature-attribute-row--readonly .feature-attribute-value {
+    cursor: default;
+}
+
+/* Read-only attributes section spacing */
+.feature-readonly-attributes-section {
+    padding: 0 12px;
+}
+
+/* Read-only type selector item: non-interactive */
+.group-type-selector-item--readonly {
+    cursor: default;
+    pointer-events: none;
+}
+
 /* =========================================================================
    MAP CONTEXT MENU
    ========================================================================= */

--- a/src/js/sidebar/components/feature-identification.js
+++ b/src/js/sidebar/components/feature-identification.js
@@ -5,7 +5,7 @@
  * Displays feature icon, name, type, layer information, and description.
  */
 
-import { getLayers, getFeatureIcon, getFeatureDisplayName, getFeatureById, updateFeature, getStorageTypeFromSource } from '../../store/index.js';
+import { getLayers, getFeatureIcon, getFeatureDisplayName, getFeatureById, updateFeature, getStorageTypeFromSource, isCurrentMapLockedSync } from '../../store/index.js';
 import { createFeatureOptionsButton } from '../../tool_manager/helpers/feature-header.helpers.js';
 
 /**
@@ -86,47 +86,54 @@ export async function createFeatureIdentification(options) {
     const nameDisplay = document.createElement('div');
     nameDisplay.className = 'feature-identification-name';
     nameDisplay.textContent = feature.properties?.nome || 'Sem nome';
-    nameDisplay.title = 'Clique para editar';
 
-    const nameInput = document.createElement('input');
-    nameInput.type = 'text';
-    nameInput.className = 'feature-identification-name-input';
-    nameInput.value = feature.properties?.nome || '';
-    nameInput.style.display = 'none';
+    const mapLocked = isCurrentMapLockedSync();
 
-    // Edit functionality
-    nameDisplay.addEventListener('click', () => {
-        nameDisplay.style.display = 'none';
-        nameInput.style.display = 'block';
-        nameInput.focus();
-        nameInput.select();
-    });
+    if (!mapLocked) {
+        nameDisplay.title = 'Clique para editar';
 
-    const saveEdit = () => {
-        const newName = nameInput.value.trim() || 'Sem nome';
-        nameDisplay.textContent = newName;
-        nameDisplay.style.display = 'block';
+        const nameInput = document.createElement('input');
+        nameInput.type = 'text';
+        nameInput.className = 'feature-identification-name-input';
+        nameInput.value = feature.properties?.nome || '';
         nameInput.style.display = 'none';
 
-        if (onNameChange && newName !== feature.properties?.nome) {
-            onNameChange(newName);
-        }
-    };
+        // Edit functionality
+        nameDisplay.addEventListener('click', () => {
+            nameDisplay.style.display = 'none';
+            nameInput.style.display = 'block';
+            nameInput.focus();
+            nameInput.select();
+        });
 
-    nameInput.addEventListener('blur', saveEdit);
-    nameInput.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter') {
-            e.preventDefault();
-            saveEdit();
-        } else if (e.key === 'Escape') {
-            nameInput.value = feature.properties?.nome || '';
+        const saveEdit = () => {
+            const newName = nameInput.value.trim() || 'Sem nome';
+            nameDisplay.textContent = newName;
             nameDisplay.style.display = 'block';
             nameInput.style.display = 'none';
-        }
-    });
 
-    nameContainer.appendChild(nameDisplay);
-    nameContainer.appendChild(nameInput);
+            if (onNameChange && newName !== feature.properties?.nome) {
+                onNameChange(newName);
+            }
+        };
+
+        nameInput.addEventListener('blur', saveEdit);
+        nameInput.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                saveEdit();
+            } else if (e.key === 'Escape') {
+                nameInput.value = feature.properties?.nome || '';
+                nameDisplay.style.display = 'block';
+                nameInput.style.display = 'none';
+            }
+        });
+
+        nameContainer.appendChild(nameDisplay);
+        nameContainer.appendChild(nameInput);
+    } else {
+        nameContainer.appendChild(nameDisplay);
+    }
 
     // Feature type label
     const typeLabel = document.createElement('div');
@@ -275,6 +282,8 @@ async function createDescriptionSection(options) {
         }
     }
 
+    const isMapLocked = isCurrentMapLockedSync();
+
     // Create the display/edit elements
     const displayContainer = document.createElement('div');
     displayContainer.className = 'feature-description-display';
@@ -288,6 +297,18 @@ async function createDescriptionSection(options) {
      */
     function renderDisplay() {
         displayContainer.innerHTML = '';
+
+        if (isMapLocked) {
+            // Locked: show description text only, no editing controls
+            if (currentDescription) {
+                const descText = document.createElement('div');
+                descText.className = 'feature-description-text';
+                descText.textContent = currentDescription;
+                displayContainer.appendChild(descText);
+            }
+            // When locked with no description, show nothing
+            return;
+        }
 
         if (!currentDescription) {
             // Show "Add description" button

--- a/src/js/sidebar/components/feature-photo-gallery.js
+++ b/src/js/sidebar/components/feature-photo-gallery.js
@@ -25,6 +25,7 @@ let _viewerImages = null;
 export async function createPhotoGallery(options) {
     const { featureId, featureType, compact = true } = options;
 
+    const mapLocked = isCurrentMapLockedSync();
     const container = document.createElement('div');
     container.className = 'feature-photo-gallery';
 
@@ -36,15 +37,22 @@ export async function createPhotoGallery(options) {
     title.className = 'feature-photo-gallery-title';
     title.textContent = 'Fotos / Imagens';
 
-    const addButton = document.createElement('button');
-    addButton.className = 'feature-photo-gallery-add-btn';
-    addButton.innerHTML = `
-        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
-        Adicionar
-    `;
-
     header.appendChild(title);
-    header.appendChild(addButton);
+
+    if (!mapLocked) {
+        const addButton = document.createElement('button');
+        addButton.className = 'feature-photo-gallery-add-btn';
+        addButton.innerHTML = `
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+            Adicionar
+        `;
+        addButton.addEventListener('click', () => {
+            if (isCurrentMapLockedSync()) return;
+            fileInput.click();
+        });
+        header.appendChild(addButton);
+    }
+
     container.appendChild(header);
 
     // Grid container
@@ -73,17 +81,26 @@ export async function createPhotoGallery(options) {
 
         const images = await userDataManager.getImages(featureId, featureType);
 
+        // When map is locked and no images, hide the entire gallery
+        if (mapLocked && images.length === 0) {
+            container.classList.add('feature-photo-gallery--hidden');
+            return;
+        }
+        container.classList.remove('feature-photo-gallery--hidden');
+
         // Show images (limited to 5 in compact mode + add button)
         const maxVisible = compact ? 5 : images.length;
         const visibleImages = images.slice(0, maxVisible);
 
         visibleImages.forEach(img => {
-            const card = createImageCard(img, featureId, featureType, renderImages, images);
+            const card = mapLocked
+                ? createReadOnlyImageCard(img, images)
+                : createImageCard(img, featureId, featureType, renderImages, images);
             grid.appendChild(card);
         });
 
         // Add button card (hide when map is locked)
-        if (!isCurrentMapLockedSync() && images.length <= 2) {
+        if (!mapLocked && images.length <= 2) {
             const addCard = createAddCard(fileInput);
             grid.appendChild(addCard);
         }
@@ -91,10 +108,10 @@ export async function createPhotoGallery(options) {
         // Update counter
         if (images.length > 0) {
             counter.textContent = `${images.length} ${images.length === 1 ? 'imagem anexada' : 'imagens anexadas'}`;
-            counter.style.display = 'block';
+            counter.classList.remove('feature-photo-gallery-counter--hidden');
         } else {
             counter.textContent = '';
-            counter.style.display = 'none';
+            counter.classList.add('feature-photo-gallery-counter--hidden');
         }
     }
 
@@ -112,12 +129,6 @@ export async function createPhotoGallery(options) {
             }
             fileInput.value = '';
         }
-    });
-
-    // Add button click
-    addButton.addEventListener('click', () => {
-        if (isCurrentMapLockedSync()) return;
-        fileInput.click();
     });
 
     // Subscribe to image updates
@@ -188,6 +199,29 @@ function createImageCard(imageData, featureId, featureType, onDelete, allImages)
     card.appendChild(img);
     card.appendChild(deleteBtn);
 
+    return card;
+}
+
+/**
+ * Creates a read-only image card (no delete button).
+ * @param {Object} imageData - Image data object
+ * @param {Array<Object>} allImages - All images for navigation
+ * @returns {HTMLElement} Image card element
+ */
+function createReadOnlyImageCard(imageData, allImages) {
+    const card = document.createElement('div');
+    card.className = 'feature-photo-gallery-card';
+
+    const img = document.createElement('img');
+    img.src = imageData.thumbnail || imageData.data;
+    img.alt = imageData.name || 'Imagem';
+    img.loading = 'lazy';
+
+    img.addEventListener('click', () => {
+        openImageViewer(imageData, allImages);
+    });
+
+    card.appendChild(img);
     return card;
 }
 

--- a/src/js/sidebar/components/group-type-selector.js
+++ b/src/js/sidebar/components/group-type-selector.js
@@ -41,14 +41,16 @@ function getTypePluralLabel(type) {
 /**
  * Creates a group type selector component.
  * Shows a list of feature types present in the group, allowing selection to edit style.
+ * In readOnly mode, shows only types and counts without interaction.
  *
  * @param {Object} options - Configuration options
  * @param {Array} options.selectedFeatures - All selected features in the group
  * @param {Function} options.onTypeSelect - Callback when a type is selected (receives type and features)
+ * @param {boolean} [options.readOnly=false] - When true, shows types/counts only without editing
  * @returns {Object} Object with element and cleanup function
  */
 export function createGroupTypeSelector(options) {
-    const { selectedFeatures, onTypeSelect } = options;
+    const { selectedFeatures, onTypeSelect, readOnly = false } = options;
 
     const container = document.createElement('div');
     container.className = 'group-type-selector';
@@ -65,14 +67,16 @@ export function createGroupTypeSelector(options) {
         featuresByType.get(type).push(feature);
     }
 
-    // Header
-    const header = document.createElement('div');
-    header.className = 'group-type-selector-header';
-    header.innerHTML = `
-        <span class="group-type-selector-title">Editar por tipo</span>
-        <span class="group-type-selector-hint">Selecione um tipo para editar seu estilo</span>
-    `;
-    container.appendChild(header);
+    if (!readOnly) {
+        // Header (only in editable mode)
+        const header = document.createElement('div');
+        header.className = 'group-type-selector-header';
+        header.innerHTML = `
+            <span class="group-type-selector-title">Editar por tipo</span>
+            <span class="group-type-selector-hint">Selecione um tipo para editar seu estilo</span>
+        `;
+        container.appendChild(header);
+    }
 
     // Type list
     const typeList = document.createElement('div');
@@ -81,35 +85,49 @@ export function createGroupTypeSelector(options) {
     let selectedTypeButton = null;
 
     for (const [type, features] of featuresByType) {
-        const typeButton = document.createElement('button');
-        typeButton.className = 'group-type-selector-item';
-        typeButton.type = 'button';
-
         const iconPath = getFeatureIcon(type) || './images/icon_point_black.svg';
         const label = getTypePluralLabel(type);
         const count = features.length;
 
-        typeButton.innerHTML = `
-            <img src="${iconPath}" alt="${label}" class="group-type-selector-icon" />
-            <span class="group-type-selector-label">${label}</span>
-            <span class="group-type-selector-count">${count}</span>
-        `;
+        if (readOnly) {
+            // Read-only: non-interactive item
+            const typeItem = document.createElement('div');
+            typeItem.className = 'group-type-selector-item group-type-selector-item--readonly';
 
-        typeButton.addEventListener('click', () => {
-            // Update active state
-            if (selectedTypeButton) {
-                selectedTypeButton.classList.remove('active');
-            }
-            typeButton.classList.add('active');
-            selectedTypeButton = typeButton;
+            typeItem.innerHTML = `
+                <img src="${iconPath}" alt="${label}" class="group-type-selector-icon" />
+                <span class="group-type-selector-label">${label}</span>
+                <span class="group-type-selector-count">${count}</span>
+            `;
 
-            // Call callback with type and its features
-            if (onTypeSelect) {
-                onTypeSelect(type, features);
-            }
-        });
+            typeList.appendChild(typeItem);
+        } else {
+            const typeButton = document.createElement('button');
+            typeButton.className = 'group-type-selector-item';
+            typeButton.type = 'button';
 
-        typeList.appendChild(typeButton);
+            typeButton.innerHTML = `
+                <img src="${iconPath}" alt="${label}" class="group-type-selector-icon" />
+                <span class="group-type-selector-label">${label}</span>
+                <span class="group-type-selector-count">${count}</span>
+            `;
+
+            typeButton.addEventListener('click', () => {
+                // Update active state
+                if (selectedTypeButton) {
+                    selectedTypeButton.classList.remove('active');
+                }
+                typeButton.classList.add('active');
+                selectedTypeButton = typeButton;
+
+                // Call callback with type and its features
+                if (onTypeSelect) {
+                    onTypeSelect(type, features);
+                }
+            });
+
+            typeList.appendChild(typeButton);
+        }
     }
 
     container.appendChild(typeList);

--- a/src/js/sidebar/panels/feature-panel-content.js
+++ b/src/js/sidebar/panels/feature-panel-content.js
@@ -15,6 +15,7 @@ import { createLocationSection } from '../components/feature-location-section.js
 import { createGroupTypeSelector } from '../components/group-type-selector.js';
 import { createMultiSelectionActions } from '../components/multi-selection-actions.js';
 import { isCurrentMapLockedSync, startBatchUndo, commitBatchUndo, discardBatchUndo } from '../../store';
+import { renderReadOnlyAttributesSection } from '../../user_data/attributes_tab_renderer.js';
 
 // ============================================================================
 // CONSTANTS
@@ -264,129 +265,151 @@ export async function createFeaturePanelContent({
         cleanupFunctions.push(photoGallery.cleanup);
     }
 
-    // 3. Info section before tabs (for LOS and similar analysis tools)
-    if (isSingleSelection && control && typeof control.createInfoSection === 'function') {
-        try {
-            const infoSection = control.createInfoSection(selectedFeatures[0]);
-            if (infoSection) {
-                container.appendChild(infoSection);
-            }
-        } catch (error) {
-            console.error(`Error creating info section for ${featureType}:`, error);
-        }
-    }
-
-    // 4. Tabs (Estilo / Parâmetros / Atributos) - only show for single selection or multiple same-type
-    // For mixed types, show group type selector to edit by type
-    if (!isMixedTypes) {
-        const featureTabs = createFeatureTabs({
-            featureId,
-            featureType,
-            singleSelection: isSingleSelection
-        });
-        container.appendChild(featureTabs.container);
-        cleanupFunctions.push(featureTabs.cleanup);
-
-        // Inject tool-specific style controls into the Style tab
-        if (control && control.hasAttributePanel && control.hasAttributePanel()) {
-            try {
-                control.createAttributePanel(
-                    featureTabs.styleTab,
-                    selectedFeatures,
-                    selectionManager,
-                    uiManager,
-                    { hideHeader: true }
-                );
-            } catch (error) {
-                console.error(`Error creating attribute panel for ${featureType}:`, error);
-            }
+    // When map is locked: skip tabs/style/parameters, show read-only attributes directly
+    if (mapLocked) {
+        // Read-only attributes section (only if attributes exist)
+        if (isSingleSelection) {
+            const readOnlyAttrsContainer = document.createElement('div');
+            readOnlyAttrsContainer.className = 'feature-readonly-attributes-section';
+            await renderReadOnlyAttributesSection(readOnlyAttrsContainer, featureId, featureType);
+            container.appendChild(readOnlyAttrsContainer);
         }
 
-        // Inject parameters controls into Parameters tab (for LOS and similar tools)
-        if (featureTabs.parametersTab && control && typeof control.createParametersPanel === 'function') {
-            try {
-                control.createParametersPanel(
-                    featureTabs.parametersTab,
-                    selectedFeatures,
-                    selectionManager,
-                    uiManager
-                );
-                // Register cleanup for terrain listener attached by parameters panel
-                if (featureTabs.parametersTab._parametersCleanup) {
-                    cleanupFunctions.push(featureTabs.parametersTab._parametersCleanup);
-                }
-            } catch (error) {
-                console.error(`Error creating parameters panel for ${featureType}:`, error);
-            }
+        // For mixed types in locked mode: show read-only type summary
+        if (!isSingleSelection && isMixedTypes) {
+            const typeSelector = createGroupTypeSelector({
+                selectedFeatures,
+                readOnly: true,
+                onTypeSelect: () => {}
+            });
+            container.appendChild(typeSelector.element);
+            cleanupFunctions.push(typeSelector.cleanup);
         }
     } else {
-        // Mixed types: show group type selector
-        const typeTabsContainer = document.createElement('div');
-        typeTabsContainer.className = 'group-type-tabs-container';
-
-        // Track state for each type that was edited
-        const editedTypesState = new Map();
-
-        const typeSelector = createGroupTypeSelector({
-            selectedFeatures,
-            onTypeSelect: (selectedType, featuresOfType) => {
-                // Clear previous tabs content
-                typeTabsContainer.innerHTML = '';
-
-                // Get control for this type
-                const typeControl = selectionManager?.controls.get(selectedType);
-
-                // Store initial properties for this type if not already stored
-                if (!editedTypesState.has(selectedType)) {
-                    editedTypesState.set(selectedType, {
-                        control: typeControl,
-                        features: featuresOfType,
-                        initialPropertiesMap: new Map(
-                            featuresOfType.map(f => [f.properties.id, { ...f.properties }])
-                        )
-                    });
+        // 3. Info section before tabs (for LOS and similar analysis tools)
+        if (isSingleSelection && control && typeof control.createInfoSection === 'function') {
+            try {
+                const infoSection = control.createInfoSection(selectedFeatures[0]);
+                if (infoSection) {
+                    container.appendChild(infoSection);
                 }
+            } catch (error) {
+                console.error(`Error creating info section for ${featureType}:`, error);
+            }
+        }
 
-                // Create tabs for this type (multi-selection mode)
-                const typeTabs = createFeatureTabs({
-                    featureId: featuresOfType[0]?.properties?.id,
-                    featureType: selectedType,
-                    singleSelection: false
-                });
-                typeTabsContainer.appendChild(typeTabs.container);
+        // 4. Tabs (Estilo / Parâmetros / Atributos) - only show for single selection or multiple same-type
+        // For mixed types, show group type selector to edit by type
+        if (!isMixedTypes) {
+            const featureTabs = createFeatureTabs({
+                featureId,
+                featureType,
+                singleSelection: isSingleSelection
+            });
+            container.appendChild(featureTabs.container);
+            cleanupFunctions.push(featureTabs.cleanup);
 
-                // Inject style controls for this type (hide buttons, we'll add global ones)
-                if (typeControl && typeControl.hasAttributePanel && typeControl.hasAttributePanel()) {
-                    try {
-                        typeControl.createAttributePanel(
-                            typeTabs.styleTab,
-                            featuresOfType,
-                            selectionManager,
-                            uiManager,
-                            { hideHeader: true, hideButtons: true }
-                        );
-                    } catch (error) {
-                        console.error(`Error creating attribute panel for ${selectedType}:`, error);
-                    }
+            // Inject tool-specific style controls into the Style tab
+            if (control && control.hasAttributePanel && control.hasAttributePanel()) {
+                try {
+                    control.createAttributePanel(
+                        featureTabs.styleTab,
+                        selectedFeatures,
+                        selectionManager,
+                        uiManager,
+                        { hideHeader: true }
+                    );
+                } catch (error) {
+                    console.error(`Error creating attribute panel for ${featureType}:`, error);
                 }
             }
-        });
 
-        container.appendChild(typeSelector.element);
-        container.appendChild(typeTabsContainer);
+            // Inject parameters controls into Parameters tab (for LOS and similar tools)
+            if (featureTabs.parametersTab && control && typeof control.createParametersPanel === 'function') {
+                try {
+                    control.createParametersPanel(
+                        featureTabs.parametersTab,
+                        selectedFeatures,
+                        selectionManager,
+                        uiManager
+                    );
+                    // Register cleanup for terrain listener attached by parameters panel
+                    if (featureTabs.parametersTab._parametersCleanup) {
+                        cleanupFunctions.push(featureTabs.parametersTab._parametersCleanup);
+                    }
+                } catch (error) {
+                    console.error(`Error creating parameters panel for ${featureType}:`, error);
+                }
+            }
+        } else {
+            // Mixed types: show group type selector
+            const typeTabsContainer = document.createElement('div');
+            typeTabsContainer.className = 'group-type-tabs-container';
 
-        // Create global Save/Discard buttons for all types
-        const globalButtons = createGlobalButtons({
-            editedTypesState,
-            selectionManager
-        });
-        container.appendChild(globalButtons.element);
+            // Track state for each type that was edited
+            const editedTypesState = new Map();
 
-        // Cleanup: save all edited types before destroying
-        cleanupFunctions.push(() => {
-            globalButtons.saveAll();
-            typeSelector.cleanup();
-        });
+            const typeSelector = createGroupTypeSelector({
+                selectedFeatures,
+                onTypeSelect: (selectedType, featuresOfType) => {
+                    // Clear previous tabs content
+                    typeTabsContainer.innerHTML = '';
+
+                    // Get control for this type
+                    const typeControl = selectionManager?.controls.get(selectedType);
+
+                    // Store initial properties for this type if not already stored
+                    if (!editedTypesState.has(selectedType)) {
+                        editedTypesState.set(selectedType, {
+                            control: typeControl,
+                            features: featuresOfType,
+                            initialPropertiesMap: new Map(
+                                featuresOfType.map(f => [f.properties.id, { ...f.properties }])
+                            )
+                        });
+                    }
+
+                    // Create tabs for this type (multi-selection mode)
+                    const typeTabs = createFeatureTabs({
+                        featureId: featuresOfType[0]?.properties?.id,
+                        featureType: selectedType,
+                        singleSelection: false
+                    });
+                    typeTabsContainer.appendChild(typeTabs.container);
+
+                    // Inject style controls for this type (hide buttons, we'll add global ones)
+                    if (typeControl && typeControl.hasAttributePanel && typeControl.hasAttributePanel()) {
+                        try {
+                            typeControl.createAttributePanel(
+                                typeTabs.styleTab,
+                                featuresOfType,
+                                selectionManager,
+                                uiManager,
+                                { hideHeader: true, hideButtons: true }
+                            );
+                        } catch (error) {
+                            console.error(`Error creating attribute panel for ${selectedType}:`, error);
+                        }
+                    }
+                }
+            });
+
+            container.appendChild(typeSelector.element);
+            container.appendChild(typeTabsContainer);
+
+            // Create global Save/Discard buttons for all types
+            const globalButtons = createGlobalButtons({
+                editedTypesState,
+                selectionManager
+            });
+            container.appendChild(globalButtons.element);
+
+            // Cleanup: save all edited types before destroying
+            cleanupFunctions.push(() => {
+                globalButtons.saveAll();
+                typeSelector.cleanup();
+            });
+        }
     }
 
     // 5. Location section (only for single selection)

--- a/src/js/user_data/attributes_tab_renderer.js
+++ b/src/js/user_data/attributes_tab_renderer.js
@@ -341,6 +341,70 @@ function renderEmptyState(container) {
 }
 
 /**
+ * Renders a read-only attributes section for locked map view.
+ * Shows a titled section with key-value pairs (not editable).
+ * Returns nothing visible if no attributes exist.
+ *
+ * @param {HTMLElement} container - Container to render into
+ * @param {string} featureId - Feature ID
+ * @param {string} featureType - Feature type
+ * @returns {Promise<void>}
+ */
+export async function renderReadOnlyAttributesSection(container, featureId, featureType) {
+    container.innerHTML = '';
+
+    const attributes = await userDataManager.getAttributes(featureId, featureType);
+    const entries = Object.entries(attributes);
+
+    // When locked with no attributes, show nothing (clean)
+    if (entries.length === 0) return;
+
+    // Section title styled like feature-photo-gallery-title
+    const header = document.createElement('div');
+    header.className = 'feature-photo-gallery-header';
+
+    const title = document.createElement('span');
+    title.className = 'feature-photo-gallery-title';
+    title.textContent = 'Atributos';
+
+    header.appendChild(title);
+    container.appendChild(header);
+
+    // Read-only attribute list
+    const listContainer = document.createElement('div');
+    listContainer.className = 'feature-attributes-list';
+
+    entries.forEach(([key, value]) => {
+        const row = document.createElement('div');
+        row.className = 'feature-attribute-row feature-attribute-row--readonly';
+
+        const keyContainer = document.createElement('div');
+        keyContainer.className = 'feature-attribute-key-container';
+
+        const keySpan = document.createElement('span');
+        keySpan.className = 'feature-attribute-key';
+        keySpan.textContent = key;
+
+        keyContainer.appendChild(keySpan);
+
+        const valueContainer = document.createElement('div');
+        valueContainer.className = 'feature-attribute-value-container';
+
+        const valueSpan = document.createElement('span');
+        valueSpan.className = 'feature-attribute-value';
+        valueSpan.textContent = value || '—';
+
+        valueContainer.appendChild(valueSpan);
+
+        row.appendChild(keyContainer);
+        row.appendChild(valueContainer);
+        listContainer.appendChild(row);
+    });
+
+    container.appendChild(listContainer);
+}
+
+/**
  * Mostra mensagem de erro.
  * @private
  * @param {HTMLElement} container - Container onde mostrar o erro


### PR DESCRIPTION
When a map is locked, the feature panel now shows a presentable read-only view instead of disabled editing controls:

- Identification section kept with non-editable name/description
- Photo gallery only shown when images exist, no add/delete buttons
- No style or parameter tabs — attributes shown directly
- Read-only attributes section with title only when attributes exist
- Location section preserved for applicable feature types
- Multi-selection: type list shows types/counts without edit controls
- No "Editar por tipo" header or clickable items in locked mode