### PR TITLE
fix: sync StateManager state in _collapsePanel to prevent layout shif…

### DIFF
--- a/src/js/sidebar/sidebar.control.js
+++ b/src/js/sidebar/sidebar.control.js
@@ -782,6 +782,8 @@ export class SidebarControl {
 
     /**
      * Collapses the panel.
+     * Ensures StateManager state is consistent with the visual collapse.
+     * Safe to call even when state is already collapsed (set() is a no-op for equal values).
      * @private
      */
     _collapsePanel() {
@@ -794,6 +796,14 @@ export class SidebarControl {
 
         this._collapsedSidebar.setActiveTab(null);
         this._panel.collapse();
+
+        // Sync StateManager to prevent sidebar.expanded from staying true
+        // when the panel is visually collapsed by non-collapseSidebar paths
+        // (e.g. vector info panel, search result panel, tool panel).
+        // set() uses deepEqual and is a no-op when the value hasn't changed,
+        // so this is safe to call from any code path.
+        this._stateManager.set('sidebar.expanded', false);
+        this._stateManager.set('sidebar.activeTab', null);
     }
 
     /**


### PR DESCRIPTION
_collapsePanel() only performed a visual collapse without updating sidebar.expanded in StateManager. This caused search-bar, chips, and base-layer-selector to remain displaced when the sidebar was closed through non-collapseSidebar paths (vector info panel, search result panel, tool panel).

